### PR TITLE
Various Improvements

### DIFF
--- a/WotC_VestSlot/Config/XComVestSlot.ini
+++ b/WotC_VestSlot/Config/XComVestSlot.ini
@@ -7,11 +7,11 @@
 
 +AllowedItemCategories = "defense"
 
-;	If this is set to "true", the Vest Slot will attempt to always be occupied 
+;	If this is set to "false", the Vest Slot will attempt to always be occupied 
 ;	by an infinite item with a valid item category and the highest tier.
 ;	Note: this does not apply to soldiers that you meet for the first time in Tactical, 
 ;	such as soldiers you get on Gatecrasher.
-bDisallowEmpty = false
+bAllowEmpty = true
 
 ;	You can specify Character Template Names of units that will always have access to the Vest Slot.
 ;	Note: do not confuse Character Template Name with Soldier Class Name.

--- a/WotC_VestSlot/Config/XComVestSlot.ini
+++ b/WotC_VestSlot/Config/XComVestSlot.ini
@@ -4,3 +4,24 @@
 ; the default behavior (all soldiers have vest slots) is disabled
 ; and only soldier with this abilities gain a vest slot
 ;+AbilityUnlocksVestSlot=AbilityTemplateName
+
++AllowedItemCategories = "defense"
+
+bLog = true
+
+;	If this is set to "true", the Vest Slot will attempt to always be occupied 
+;	by an infinite item with a valid item category and the highest tier.
+;	Note: this does not apply to soldiers that you meet for the first time in Tactical, 
+;	such as soldiers you get on Gatecrasher.
+bDisallowEmpty = false
+
+;	You can specify Character Template Names of units that will always have access to the Vest Slot.
+;	Note: do not confuse Character Template Name with Soldier Class Name.
+;+AllowedCharacterTemplates = "SparkSoldier"
+
+;	You can specify Soldier Class Names of soldiers that will always have access to the Vest Slot.
+;+AllowedSoldierClasses="Akimbo"
+
+;	If this is set to "true", the mod will output debug logging in the log file:
+;	..\Documents\my games\XCOM2 War of the Chosen\XComGame\Logs\Launch.log
+bLog = false

--- a/WotC_VestSlot/Config/XComVestSlot.ini
+++ b/WotC_VestSlot/Config/XComVestSlot.ini
@@ -7,8 +7,6 @@
 
 +AllowedItemCategories = "defense"
 
-bLog = true
-
 ;	If this is set to "true", the Vest Slot will attempt to always be occupied 
 ;	by an infinite item with a valid item category and the highest tier.
 ;	Note: this does not apply to soldiers that you meet for the first time in Tactical, 

--- a/WotC_VestSlot/Src/WotC_VestSlot/Classes/X2StrategyElement_VestSlot.uc
+++ b/WotC_VestSlot/Src/WotC_VestSlot/Classes/X2StrategyElement_VestSlot.uc
@@ -4,6 +4,13 @@ var localized string strVestFirstLetter;
 
 var config array<name> AbilityUnlocksVestSlot;
 
+var config bool bLog;
+var config array<name> AllowedItemCategories;
+var config bool bDisallowEmpty;
+
+var config array<name> AllowedSoldierClasses;
+var config array<name> AllowedCharacterTemplates;
+
 static function array<X2DataTemplate> CreateTemplates()
 {
 	local array<X2DataTemplate> Templates;
@@ -42,12 +49,17 @@ static function X2DataTemplate CreateVestSlotTemplate()
 static function bool CanAddItemToVestSlot(CHItemSlot Slot, XComGameState_Unit Unit, X2ItemTemplate Template, optional XComGameState CheckGameState, optional int Quantity = 1, optional XComGameState_Item ItemState)
 {
 	local string strDummy;
-	`log(GetFuncName() @ "called");
+
 	if (!Slot.UnitHasSlot(Unit, strDummy, CheckGameState) || Unit.GetItemInSlot(Slot.InvSlot, CheckGameState) != none)
 	{
+		`LOG(Unit.GetFullName() @ "can NOT add item to Vest Slot:" @ Template.FriendlyName @ Template.DataName @ ", because unit does not have the Vest Slot:" @ !Slot.UnitHasSlot(Unit, strDummy, CheckGameState) @ "or" @ "the Vest Slot is already occupied:" @ Unit.GetItemInSlot(Slot.InvSlot, CheckGameState) != none, default.bLog, 'WotC_VestSlot');
 		return false;
 	}
-	return Template.ItemCat == 'defense';
+	if (default.AllowedItemCategories.Find(Template.ItemCat) != INDEX_NONE)
+	{
+		`LOG(Unit.GetFullName() @ "can add item to Vest Slot:" @ Template.FriendlyName @ Template.DataName @ ", because it has a matching Item Category:" @ Template.ItemCat, default.bLog, 'WotC_VestSlot');
+		return true;
+	}
 }
 
 static function bool HasVestSlot(CHItemSlot Slot, XComGameState_Unit UnitState, out string LockedReason, optional XComGameState CheckGameState)
@@ -57,59 +69,72 @@ static function bool HasVestSlot(CHItemSlot Slot, XComGameState_Unit UnitState, 
 	local array<XComGameState_Item> CurrentInventory;
 	local XComGameState_Item InventoryItem;
 
-
-	`log(GetFuncName() @ "called");
-
-	if (default.AbilityUnlocksVestSlot.Length == 0)
+	//	Check for whitelisted soldier classes first.
+	if (default.AllowedSoldierClasses.Find(UnitState.GetSoldierClassTemplateName()) != INDEX_NONE)
 	{
-		return UnitState.IsSoldier() && !UnitState.IsRobotic();
+		`LOG(UnitState.GetFullName() @ "has Vest Slot, because they have a matching Soldier Class:" @ UnitState.GetSoldierClassTemplateName(), default.bLog, 'WotC_VestSlot');
+		return true;
 	}
-
-	foreach default.AbilityUnlocksVestSlot(Ability)
-	{
-		if (UnitState.HasSoldierAbility(Ability, true))
-		{
-			`LOG(GetFuncName() @ "unlocked by" @ Ability,, 'VestSlot');
-			return true;
-		}
+	//	Then check whitelisted character templates. Can come in handy if there are any robotic soldier classes.
+	if (default.AllowedCharacterTemplates.Find(UnitState.GetMyTemplateName()) != INDEX_NONE)
+	{	
+		`LOG(UnitState.GetFullName() @ "has Vest Slot, because they have a matching Character Template Name:" @ UnitState.GetMyTemplateName(), default.bLog, 'WotC_VestSlot');
+		return true;
 	}
-
-	CurrentInventory = UnitState.GetAllInventoryItems(CheckGameState);
-	foreach CurrentInventory(InventoryItem)
+	//	If there is no soldier class match, check if there are any entries in the config array for abilities that unlock the Vest Slot.
+	if (default.AbilityUnlocksVestSlot.Length != 0)
 	{
-		EquipmentTemplate = X2EquipmentTemplate(InventoryItem.GetMyTemplate());
-		if (EquipmentTemplate != none)
+		foreach default.AbilityUnlocksVestSlot(Ability)
 		{
-			foreach EquipmentTemplate.Abilities(Ability)
+			if (UnitState.HasSoldierAbility(Ability, true))
 			{
-				if (default.AbilityUnlocksVestSlot.Find(Ability) != INDEX_NONE)
+				`LOG(UnitState.GetFullName() @ "has Vest Slot, because they have a matching Ability:" @ Ability, default.bLog, 'WotC_VestSlot');
+				return true;
+			}
+		}
+
+		CurrentInventory = UnitState.GetAllInventoryItems(CheckGameState);
+		foreach CurrentInventory(InventoryItem)
+		{
+			EquipmentTemplate = X2EquipmentTemplate(InventoryItem.GetMyTemplate());
+			if (EquipmentTemplate != none)
+			{
+				foreach EquipmentTemplate.Abilities(Ability)
 				{
-					`LOG(GetFuncName() @ "unlocked by" @ Ability,, 'VestSlot');
-					return true;
+					if (default.AbilityUnlocksVestSlot.Find(Ability) != INDEX_NONE)
+					{
+						`LOG(UnitState.GetFullName() @ "has Vest Slot, because they have a matching Ability:" @ Ability @ "on an equipped Item:" @ EquipmentTemplate.DataName @ "in slot:" @ InventoryItem.InventorySlot, default.bLog, 'WotC_VestSlot');
+						return true;
+					}
 				}
 			}
 		}
+
+		//	If the config array has at least one ability, we do not add the slot to all soldiers.
+		`LOG(UnitState.GetFullName() @ "does not have Vest Slot, because they do not have any abilities from the configured list.", default.bLog, 'WotC_VestSlot');
+		return false;
+
+	}	//	If there are no entries in the ability config array, allow the Slot for all non-robotic soldiers.
+	else if(UnitState.IsSoldier() && !UnitState.IsRobotic())
+	{
+		`LOG(UnitState.GetFullName() @ "has Vest Slot, because they are a non-robotic soldier.", default.bLog, 'WotC_VestSlot');
+		return true;
 	}
-
-	return false;
-
-	
+	return false;	
 }
 
 static function int VestGetPriority(CHItemSlot Slot, XComGameState_Unit UnitState, optional XComGameState CheckGameState)
 {
-	`log(GetFuncName() @ "called");
 	return 120; // Ammo Pocket is 110 
 }
 
 static function bool ShowVestItemInLockerList(CHItemSlot Slot, XComGameState_Unit Unit, XComGameState_Item ItemState, X2ItemTemplate ItemTemplate, XComGameState CheckGameState)
 {
-	return ItemTemplate.ItemCat == 'defense';
+	return default.AllowedItemCategories.Find(ItemTemplate.ItemCat) != INDEX_NONE;
 }
 
 static function string GetVestDisplayLetter(CHItemSlot Slot)
 {
-	`log(GetFuncName() @ "called");
 	return default.strVestFirstLetter;
 }
 
@@ -120,23 +145,81 @@ static function VestValidateLoadout(CHItemSlot Slot, XComGameState_Unit Unit, XC
 	local bool HasSlot;
 	EquippedVest = Unit.GetItemInSlot(Slot.InvSlot, NewGameState);
 	HasSlot = Slot.UnitHasSlot(Unit, strDummy, NewGameState);
-	`log(GetFuncName() @ "called");
-	if(EquippedVest == none && HasSlot)
+
+	`LOG(Unit.GetFullName() @ "validating Vest Slot. Unit has slot:" @ HasSlot @ EquippedVest == none ? ", slot is empty." : ", slot contains item:" @ EquippedVest.GetMyTemplateName(), default.bLog, 'WotC_VestSlot');
+
+	if(EquippedVest == none && HasSlot && default.bDisallowEmpty)
 	{
-		//EquippedSecondaryWeapon = GetBestSecondaryWeapon(NewGameState);
-		//AddItemToInventory(EquippedSecondaryWeapon, eInvSlot_SecondaryWeapon, NewGameState);
+		EquippedVest = FindBestVest(Unit, XComHQ, NewGameState);
+		if (EquippedVest != none)
+		{
+			`LOG("Empty slot is not allowed, equipping:" @ EquippedVest.GetMyTemplateName(), default.bLog, 'WotC_VestSlot');
+			Unit.AddItemToInventory(EquippedVest, eInvSlot_Vest, NewGameState);
+		}
+		else `LOG("Empty slot is not allowed, but the mod was unable to find an infinite item to fill the slot.", default.bLog, 'WotC_VestSlot');
 	}
 	else if(EquippedVest != none && !HasSlot)
 	{
+		`LOG("WARNING Unit has an item equipped in the Vest Slot, but they do not have the Vest Slot. Unequipping the item and putting it into HQ Inventory.", default.bLog, 'WotC_VestSlot');
 		EquippedVest = XComGameState_Item(NewGameState.ModifyStateObject(class'XComGameState_Item', EquippedVest.ObjectID));
 		Unit.RemoveItemFromInventory(EquippedVest, NewGameState);
 		XComHQ.PutItemInInventory(NewGameState, EquippedVest);
 		EquippedVest = none;
 	}
+}
 
+private static function XComGameState_Item FindBestVest(const XComGameState_Unit UnitState, XComGameState_HeadquartersXCom XComHQ, XComGameState NewGameState)
+{
+	local X2EquipmentTemplate				EquipmentTemplate;
+	local XComGameStateHistory				History;
+	local int								HighestTier;
+	local XComGameState_Item				ItemState;
+	local XComGameState_Item				BestItemState;
+	local StateObjectReference				ItemRef;
+
+	HighestTier = -999;
+	History = `XCOMHISTORY;
+
+	//	Cycle through all items in HQ Inventory
+	foreach XComHQ.Inventory(ItemRef)
+	{
+		ItemState = XComGameState_Item(History.GetGameStateForObjectID(ItemRef.ObjectID));
+		if (ItemState != none)
+		{
+			EquipmentTemplate = X2EquipmentTemplate(ItemState.GetMyTemplate());
+
+			if (EquipmentTemplate != none &&	//	If this is an equippable item
+				default.AllowedItemCategories.Find(EquipmentTemplate.ItemCat) != INDEX_NONE &&	//	That has a matching Item Category
+				EquipmentTemplate.bInfiniteItem && EquipmentTemplate.Tier > HighestTier &&		//	And is of higher Tier than previously found items
+				UnitState.CanAddItemToInventory(EquipmentTemplate, eInvSlot_Vest, NewGameState, ItemState.Quantity, ItemState))	//	And can be equipped on the soldier
+			{
+				//	Remember this item as the currently best replacement option.
+				HighestTier = EquipmentTemplate.Tier;
+				BestItemState = ItemState;
+			}
+		}
+	}
+
+	if (BestItemState != none)
+	{
+		//	This will set up the Item State for modification automatically, or create a new Item State in the NewGameState if the template is infinite.
+		XComHQ.GetItemFromInventory(NewGameState, BestItemState.GetReference(), BestItemState);
+		return BestItemState;
+	}
+	else
+	{
+		return none;
+	}
 }
 
 function ECHSlotUnequipBehavior VestGetUnequipBehavior(CHItemSlot Slot, ECHSlotUnequipBehavior DefaultBehavior, XComGameState_Unit Unit, XComGameState_Item ItemState, optional XComGameState CheckGameState)
-{
-	return eCHSUB_AllowEmpty;
+{	
+	if (default.bDisallowEmpty)
+	{
+		return eCHSUB_AttemptReEquip;
+	}
+	else
+	{
+		return eCHSUB_AllowEmpty;
+	}
 }

--- a/WotC_VestSlot/Src/WotC_VestSlot/Classes/X2StrategyElement_VestSlot.uc
+++ b/WotC_VestSlot/Src/WotC_VestSlot/Classes/X2StrategyElement_VestSlot.uc
@@ -6,7 +6,7 @@ var config array<name> AbilityUnlocksVestSlot;
 
 var config bool bLog;
 var config array<name> AllowedItemCategories;
-var config bool bDisallowEmpty;
+var config bool bAllowEmpty;
 
 var config array<name> AllowedSoldierClasses;
 var config array<name> AllowedCharacterTemplates;
@@ -148,7 +148,7 @@ static function VestValidateLoadout(CHItemSlot Slot, XComGameState_Unit Unit, XC
 
 	`LOG(Unit.GetFullName() @ "validating Vest Slot. Unit has slot:" @ HasSlot @ EquippedVest == none ? ", slot is empty." : ", slot contains item:" @ EquippedVest.GetMyTemplateName(), default.bLog, 'WotC_VestSlot');
 
-	if(EquippedVest == none && HasSlot && default.bDisallowEmpty)
+	if(EquippedVest == none && HasSlot && !default.bAllowEmpty)
 	{
 		EquippedVest = FindBestVest(Unit, XComHQ, NewGameState);
 		if (EquippedVest != none)
@@ -214,12 +214,12 @@ private static function XComGameState_Item FindBestVest(const XComGameState_Unit
 
 function ECHSlotUnequipBehavior VestGetUnequipBehavior(CHItemSlot Slot, ECHSlotUnequipBehavior DefaultBehavior, XComGameState_Unit Unit, XComGameState_Item ItemState, optional XComGameState CheckGameState)
 {	
-	if (default.bDisallowEmpty)
+	if (default.bAllowEmpty)
 	{
-		return eCHSUB_AttemptReEquip;
+		return eCHSUB_AllowEmpty;
 	}
 	else
 	{
-		return eCHSUB_AllowEmpty;
+		return eCHSUB_AttemptReEquip;
 	}
 }


### PR DESCRIPTION
Debug logging is now more informative and is disabled by default.
It's now possible to configure an array of Soldier Classes and Character Templates of units that should receive the Vest Slot.
Allowed Item Categories of items that can be equipped into Vest Slot are now also configurable.
It's now possible to configure the Vest Slot so it cannot be empty. If the Vest Slot finds itself empty, it will attempt to equip an infinite item with the  Allowed Item Category of the highest tier that's currently available.
Default behavior remains the same, aside from the logging.