### PR TITLE
Check for GTS granted abilities

### DIFF
--- a/WotC_VestSlot/Config/XComVestSlot.ini
+++ b/WotC_VestSlot/Config/XComVestSlot.ini
@@ -2,7 +2,11 @@
 
 ; If there are ability entries here that unlocks the vest slot 
 ; the default behavior (all soldiers have vest slots) is disabled
-; and only soldier with this abilities gain a vest slot
+; and only soldier with this abilities gain a vest slot.
+; If the abiliy is unlocked through the GTS, the vest slot will
+; only be unlocked for soldiers affected by the GTS Unlock
+; eg. if you add CoolUnderPressure below, all Specialists will
+; gain a vest slot but other soldier classes won't be affected.
 ;+AbilityUnlocksVestSlot=AbilityTemplateName
 
 +AllowedItemCategories = "defense"


### PR DESCRIPTION
Will unlock vest slots for abilities granted by the GTS.
Abilities need to be specified in the config file like all other abilities.